### PR TITLE
HISTORY - config to dev a simple express app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ RUN apt-get update && apt-get install -y \
     openssh-client
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y neovim
+RUN apt-get install -y curl
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN apt-get install -y nodejs
 
 WORKDIR /app

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NAME=github-ssh
+NAME=express
 
 ./auth-doppler.sh
 ./build-image.sh $NAME
@@ -12,4 +12,4 @@ if [ "$(docker ps -aq -f name=$NAME)" ]; then
 fi
 
 #TODO replace $NAME in the string below
-doppler run -- bash -c 'docker run -it --name github-ssh github-ssh bash -c "mkdir -p ~/.ssh && echo \"$ID_RSA_PUB_GITHUB\" > ~/.ssh/id_rsa.pub  && echo \"$ID_RSA_GITHUB\" > ~/.ssh/id_rsa && chmod 644 ~/.ssh/id_rsa.pub && chmod 600 ~/.ssh/id_rsa && ssh-keyscan github.com >> ~/.ssh/known_hosts && git config --global user.name $GITHUB_NAME && git config --global user.email $GITHUB_EMAIL && bash"'
+doppler run -- bash -c 'docker run -it -p 4005:3000 --name express express bash -c "mkdir -p ~/.ssh && echo \"$ID_RSA_PUB_GITHUB\" > ~/.ssh/id_rsa.pub  && echo \"$ID_RSA_GITHUB\" > ~/.ssh/id_rsa && chmod 644 ~/.ssh/id_rsa.pub && chmod 600 ~/.ssh/id_rsa && ssh-keyscan github.com >> ~/.ssh/known_hosts && git config --global user.name $GITHUB_NAME && git config --global user.email $GITHUB_EMAIL && bash"'


### PR DESCRIPTION
instead of referencing branch names I'm going to refence PRs in the Express Server POC. Eventually I can make a distinct repo for the `dev-docker` variation I'm using.  
But I early to make those project, some considerations may arise: e.g. I don't even know if ubuntu is the best choice here. Maybe in two weeks using Ubuntu I may discover that using an Alpine Image is better.

with this PR's branch I developed and pushed https://github.com/uxjp/poc-express-ss--dev-docker-ubuntu to GitHub.